### PR TITLE
Bug fix: use the correct json field names for templatepdf and pdftext fields

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,8 +92,8 @@ var params = {
   // Either set the text
   text = '',
   // OR the PDF to use
-  templatePDF = '' // This is a Resource URI,
-  pdfText = {} // A mapping of labels and values
+  templatepdf = '' // This is a Resource URI,
+  pdftext = {} // A mapping of labels and values
 };
 var doc1 = new legalesign.Document(params);
 

--- a/lib/document.js
+++ b/lib/document.js
@@ -9,8 +9,8 @@ var Document = function(params) {
   this.signature_type = params.signature_type || 1;
   this.signers = params.signers || [];
   this.text = params.text || '';
-  this.templatePDF = params.templatePDF || '';
-  this.pdfText = params.pdfText || {};
+  this.templatepdf = params.templatepdf || '';
+  this.pdftext = params.pdftext || {};
 };
 
 Document.prototype.setName = function(name) {
@@ -54,17 +54,17 @@ Document.prototype.addText = function(text) {
 };
 
 Document.prototype.setTemplatePDF = function(templatePDF) {
-  this.templatePDF = templatePDF;
+  this.templatepdf = templatepdf;
   return this;
 };
 
 Document.prototype.setPDFText = function(pdfText) {
-  this.pdfText = pdfText;
+  this.pdftext = pdftext;
   return this;
 };
 
 Document.prototype.addPDFText = function(label, value) {
-  this.pdfText[label] = value;
+  this.pdftext[label] = value;
   return this;
 };
 


### PR DESCRIPTION
During testing I couldn't get it to work without this change
