### PR TITLE
Functionality and fixes

### DIFF
--- a/lib/document.js
+++ b/lib/document.js
@@ -6,11 +6,17 @@ var Document = function(params) {
   this.name = params.name || '';
   this.group = '/api/v1/group/' + (params.group || '') + '/';
   this.do_email = params.do_email || true;
-  this.signature_type = params.signature_type || 1;
+  if (params.signature_type) {
+    this.signature_type = params.signature_type || 1;
+  }
   this.signers = params.signers || [];
-  this.text = params.text || '';
-  this.templatepdf = params.templatepdf || '';
-  this.pdftext = params.pdftext || {};
+  if (params.text) {
+    this.text = params.text || '';
+  }
+  if (params.templatepdf && params.pdftext) {
+    this.templatepdf = params.templatepdf || '';
+    this.pdftext = params.pdftext || {};
+  }
 };
 
 Document.prototype.setName = function(name) {

--- a/lib/document.js
+++ b/lib/document.js
@@ -6,16 +6,10 @@ var Document = function(params) {
   this.name = params.name || '';
   this.group = '/api/v1/group/' + (params.group || '') + '/';
   this.do_email = params.do_email || true;
-  if (params.return_signer_links) {
-    this.return_signer_links = params.return_signer_links;
-  }
-  if (params.signature_type) {
-    this.signature_type = params.signature_type || 1;
-  }
+  if (params.return_signer_links) this.return_signer_links = params.return_signer_links;
+  if (params.signature_type) this.signature_type = params.signature_type || 1;
   this.signers = params.signers || [];
-  if (params.text) {
-    this.text = params.text || '';
-  }
+  if (params.text) this.text = params.text || '';
   if (params.templatepdf && params.pdftext) {
     this.templatepdf = params.templatepdf || '';
     this.pdftext = params.pdftext || {};

--- a/lib/document.js
+++ b/lib/document.js
@@ -6,6 +6,9 @@ var Document = function(params) {
   this.name = params.name || '';
   this.group = '/api/v1/group/' + (params.group || '') + '/';
   this.do_email = params.do_email || true;
+  if (params.return_signer_links) {
+    this.return_signer_links = params.return_signer_links;
+  }
   if (params.signature_type) {
     this.signature_type = params.signature_type || 1;
   }

--- a/lib/legalesign.js
+++ b/lib/legalesign.js
@@ -17,16 +17,16 @@ var Legalesign = function(apiUser, apiKey, options) {
   };
 
   this.getDefaultURL = function() {
-    return DEFAULT_URL;
+    return options.url || DEFAULT_URL;
   };
 
   this.getDefaultHeaders = function() {
-    return DEFAULT_HEADERS;
+    return options.headers || DEFAULT_HEADERS;
   };
 
   this.options = options || {};
-  this.options.url = this.options.url || this.getDefaultURL();
-  this.options.headers = this.options.headers || this.getDefaultHeaders();
+  this.options.url = this.getDefaultURL();
+  this.options.headers = this.getDefaultHeaders();
 
   // Expose Document object
   this.Document = Document;

--- a/lib/legalesign.js
+++ b/lib/legalesign.js
@@ -52,7 +52,7 @@ Legalesign.prototype.send = function(document, callback) {
       return callback(err, null);
     }
 
-    if (body !== 'OK') {
+    if (res.statusCode != 201) {
       var message = body;
       if (!body) {
         message = 'Please review Group, Signer(s) and other related document information';
@@ -60,7 +60,8 @@ Legalesign.prototype.send = function(document, callback) {
       var error = 'Legalesign Error: ' + message;
       return callback(new Error(error), null);
     }
-    return callback(null, body);
+
+    return callback(null, body, res.headers);
   });
 };
 

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
   },
   "devDependencies": {
     "chai": "^3.3.0",
-    "mocha": "^2.3.3"
+    "mocha": "^2.3.3",
+    "sinon": "1.17.6"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "legalesign",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "description": "Legalesign Node.js Helper Library",
   "main": "index.js",
   "directories": {

--- a/test/legalesign_test.js
+++ b/test/legalesign_test.js
@@ -1,0 +1,61 @@
+const chai = require('chai');
+const expect = chai.expect;
+const sinon = require('sinon');
+const request = require('request');
+const legalesign = require('../lib/legalesign');
+
+describe('Legalesign', function() {
+  beforeEach(function() {
+    this.client = legalesign('testkey', 'testsecret', {
+      url: 'testurl'
+    });
+  });
+
+  describe('resetOptions', function() {
+    it('should not reset a custom url', function() {
+      this.client.resetOptions();
+
+      expect(this.client.getDefaultURL()).to.equal('testurl');
+    });
+  });
+
+  describe('send', function() {
+    it('should return an error if the response was not 201', function() {
+      let stub = sinon.stub(request, 'post').yields(null, { statusCode: 500 }, null);
+      let spy = sinon.spy();
+
+      this.client.send({ test: true }, spy);
+
+      let response = spy.getCall(0).args[0];
+      expect(response).to.be.an('Error');
+      expect(response.message).to.equal(
+        'Legalesign Error: Please review Group, Signer(s) and other related document information');
+
+      stub.restore();
+    });
+
+    it('should return the body and headers if successful', function() {
+      let response = { test: 'test' };
+      let headers = { statusCode: 201, headers: response };
+      let stub = sinon.stub(request, 'post').yields(null, headers, response);
+      let spy = sinon.spy();
+
+      this.client.send({ test: true }, spy);
+
+      expect(spy.calledWith(null, response, response)).to.be.true;
+
+      stub.restore();
+    });
+
+    it('should return an error if request yields an error', function() {
+      let stub = sinon.stub(request, 'post').yields('error', null, null);
+      let spy = sinon.spy();
+
+      this.client.send({ test: true }, spy);
+
+      expect(spy.calledWith('error', null)).to.be.true;
+
+      stub.restore();
+    });
+  });
+});


### PR DESCRIPTION
General functionality changes:
 - Fix so that the call to reset doesn't reset an url that has been passed in as an option
 - Bumps version
 - Adds extra params to the document in line with the API and doesn't send unset optional params
 - Checks the response code from the API to determine if there was an error
 - Adds a small test to check the send method and reset method